### PR TITLE
scala-js version bump and content type improvement

### DIFF
--- a/index-fastopt.html
+++ b/index-fastopt.html
@@ -15,8 +15,8 @@ See README.md for detailed explanations.</p>
 <div id="playground">
 </div>
 
-<script type="text/javascript" src="./target/scala-2.11/example-fastopt.js"></script>
-<script type="text/javascript" src="./target/scala-2.11/example-launcher.js"></script>
+<script type="application/javascript" src="./target/scala-2.11/example-fastopt.js"></script>
+<script type="application/javascript" src="./target/scala-2.11/example-launcher.js"></script>
 
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -15,8 +15,8 @@ See README.md for detailed explanations.</p>
 <div id="playground">
 </div>
 
-<script type="text/javascript" src="./target/scala-2.11/example-opt.js"></script>
-<script type="text/javascript" src="./target/scala-2.11/example-launcher.js"></script>
+<script type="application/javascript" src="./target/scala-2.11/example-opt.js"></script>
+<script type="application/javascript" src="./target/scala-2.11/example-launcher.js"></script>
 
 </body>
 </html>

--- a/project/build.sbt
+++ b/project/build.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.4")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.5")


### PR DESCRIPTION
I believe "text/javascript" is deprecated, though admittedly it probably doesn't matter for most purposes.
