### PR TITLE
update to 0.6.13 etc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ target/
 .classpath
 .project
 .settings/
+node_modules

--- a/project/build.sbt
+++ b/project/build.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.9")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.13")

--- a/src/main/scala/example/ScalaJSExample.scala
+++ b/src/main/scala/example/ScalaJSExample.scala
@@ -26,7 +26,12 @@ object ScalaJSExample extends js.JSApp {
   def main(): Unit = {
     val paragraph = dom.document.createElement("p")
     paragraph.innerHTML = "<strong>It works!</strong>"
-    dom.document.getElementById("playground").appendChild(paragraph)
+    val playgroundTag = dom.document.getElementById("playground")
+    if (playgroundTag != null) {
+      playgroundTag.appendChild(paragraph)
+    } else {
+      dom.document.body.appendChild(paragraph)
+    }
 
     val p = paragraph.asInstanceOf[ElementExt]
   }


### PR DESCRIPTION
This PR
- update scalajs to `0.6.13` & add `node_modules` to `.gitignore`
- trivial fix for `playgroundTag` to make `ScalaJSExample` runable (without erros like `[error] TypeError: Cannot read property 'appendChild' of null`) even after adding `jsDependencies += RuntimeDOM`, since "playground" tag only exists in index-*.html, that maybe a little confusing to people who _fist time_ run a scalajs app. What do you think?
