### PR TITLE
Version bump to latest Scala.js

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -7,9 +7,7 @@ version := "0.1-SNAPSHOT"
 
 scalaVersion := "2.12.1"
 
-scalaJSUseMainModuleInitializer in Compile:= true
-
-scalaJSUseMainModuleInitializer in Test := false
+scalaJSUseMainModuleInitializer := true
 
 testFrameworks += new TestFramework("utest.runner.Framework")
 

--- a/build.sbt
+++ b/build.sbt
@@ -7,9 +7,9 @@ version := "0.1-SNAPSHOT"
 
 scalaVersion := "2.12.1"
 
-persistLauncher in Compile := true
+scalaJSUseMainModuleInitializer in Compile:= true
 
-persistLauncher in Test := false
+scalaJSUseMainModuleInitializer in Test := false
 
 testFrameworks += new TestFramework("utest.runner.Framework")
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.13
+sbt.version=0.13.15

--- a/project/build.sbt
+++ b/project/build.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.14")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.15")


### PR DESCRIPTION
Updated Scala.js and SBT versions to the latest.

Updated build.sbt to use `scalaJSUseMainModuleInitializer`.

Probably pending: "@js.native classes and objects need to have @JSGlobal"